### PR TITLE
Fix android compilation on windows

### DIFF
--- a/Source/ChessUE/Bishop.cpp
+++ b/Source/ChessUE/Bishop.cpp
@@ -7,7 +7,7 @@
 ABishop::ABishop()
 	:AChessPiece()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 

--- a/Source/ChessUE/BoardCell.cpp
+++ b/Source/ChessUE/BoardCell.cpp
@@ -55,7 +55,7 @@ void ABoardCell::BeginPlay()
 
 void ABoardCell::InitMesh()
 {
-	const TCHAR* PathToModel = L"/Game/Shape_Cube.Shape_Cube";
+	const TCHAR* PathToModel = TEXT("/Game/Shape_Cube.Shape_Cube");
 	static ConstructorHelpers::FObjectFinder<UStaticMesh> VisualAsset(PathToModel);
 
 	URoot = CreateDefaultSubobject<USceneComponent>(TEXT("root"));

--- a/Source/ChessUE/ChessPawn.cpp
+++ b/Source/ChessUE/ChessPawn.cpp
@@ -6,7 +6,7 @@
 AChessPawn::AChessPawn()
 	: AChessPiece()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 

--- a/Source/ChessUE/King.cpp
+++ b/Source/ChessUE/King.cpp
@@ -6,7 +6,7 @@
 AKing::AKing()
 	: AChessPiece()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 

--- a/Source/ChessUE/Knight.cpp
+++ b/Source/ChessUE/Knight.cpp
@@ -5,7 +5,7 @@
 
 AKnight::AKnight()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 

--- a/Source/ChessUE/Queen.cpp
+++ b/Source/ChessUE/Queen.cpp
@@ -5,7 +5,7 @@
 
 AQueen::AQueen()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 

--- a/Source/ChessUE/Rook.cpp
+++ b/Source/ChessUE/Rook.cpp
@@ -7,7 +7,7 @@
 ARook::ARook()
 	: AChessPiece()
 {
-	const TCHAR* pathToModel = L"/Game/Shape_Cone.Shape_Cone";
+	const TCHAR* pathToModel = TEXT("/Game/Shape_Cone.Shape_Cone");
 	Init(pathToModel);
 }
 


### PR DESCRIPTION
При сборке под андроид возникали ошибки компиляции при инициализации переменных
```c++
const TCHAR* var = L"s";
```
ошибка следующая
```
cannot initialize a variable of type 'const TCHAR *' (aka 'const char16_t *') with an lvalue of type 'const wchar_t [28]'
```

Использование шаблона TEXT помогло решить проблему при сборке андроида.
```c++
#if !defined(TEXT) && !UE_BUILD_DOCS
	#if PLATFORM_TCHAR_IS_CHAR16
		#define TEXT_PASTE(x) u ## x
	#else
		#define TEXT_PASTE(x) L ## x
	#endif
		#define TEXT(x) TEXT_PASTE(x)
#endif
```

По этому поводу нашел интересный закомменченый кусок в коде, непонятно что означающий
```c++
/*
// Define TEXT early	//@todo android:
#define TEXT(x) L##x

// map the Windows functions (that UE4 unfortunately uses be default) to normal functions
#define _alloca alloca
*/
```